### PR TITLE
Add liquidity order flag

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -96,6 +96,10 @@
      --><input type="checkbox" id="partiallyFillable" value=false>
       </div>
       <div class="group">
+        <label for="isLiquidityOrder">Is Liquidity Order</label><!--
+     --><input type="checkbox" id="isLiquidityOrder" value=false>
+      </div>
+      <div class="group">
         <label for="sellTokenBalance">Sell Token Balance</label><!--
      --><select id="sellTokenBalance">
           <option value="erc20" selected>erc20</option>

--- a/src/index.js
+++ b/src/index.js
@@ -53,6 +53,7 @@ function orderbookUrl(network, path) {
   return `${baseUrl}/api/${path}`;
 }
 
+// Only add properties which get hashed for the signature
 function readOrder() {
   return {
     sellToken: document.querySelector("#sellToken").value,
@@ -70,6 +71,7 @@ function readOrder() {
   };
 }
 
+// Only add properties which get hashed for the signature
 const ORDER_TYPE = [
   { name: "sellToken", type: "address" },
   { name: "buyToken", type: "address" },
@@ -160,6 +162,7 @@ document.querySelector("#quote").addEventListener(
         ...order,
         ...swapAmount,
         from: await signer.getAddress(),
+        isLiquidityOrder: document.querySelector("#isLiquidityOrder").checked ? true : undefined,
       }),
     });
 
@@ -226,6 +229,7 @@ document.querySelector("#sign").addEventListener(
           signature,
           signingScheme,
           from: await signer.getAddress(),
+          isLiquidityOrder: document.querySelector("#isLiquidityOrder").checked ? true : undefined,
         }),
       },
     );


### PR DESCRIPTION
Adds support for the `isLiquidityOrder` flag.
This is a new flag. To not break compatibility with existing integrations this flag is optional in the backend and defaults to `false` if it is not present.
Therefore the frontend only sends the flag if it's actually set to `true`.