### PR TITLE
Allow null quote ID and Goerli

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -120,7 +120,7 @@
       </div>
       <div class="group">
         <label for="quoteId">Quote ID</label><!--
-     --><input type="text" id="quoteId" value="0">
+     --><input type="text" id="quoteId" value="">
       </div>
 
       <div id="actions">

--- a/src/index.js
+++ b/src/index.js
@@ -88,6 +88,7 @@ const ORDER_TYPE = [
 const NETWORKS = {
   1: "mainnet",
   4: "rinkeby",
+  5: "goerli",
   100: "xdai",
 };
 
@@ -215,6 +216,9 @@ document.querySelector("#sign").addEventListener(
         break;
     }
 
+    const quoteIdValue = document.querySelector("#quoteId").value;
+    const quoteId = quoteIdValue === "" ? null : parseInt(quoteIdValue);
+
     const response = await fetch(
       orderbookUrl(network, "v1/orders"),
       {
@@ -226,8 +230,8 @@ document.querySelector("#sign").addEventListener(
           ...order,
           signature,
           signingScheme,
+          quoteId,
           from: await signer.getAddress(),
-          quoteId: parseInt(document.querySelector("#quoteId").value),
         }),
       },
     );


### PR DESCRIPTION
This PR does a couple of small fixes to the custom order UI. Namely:
1. Allows empty quote ID field. This can be used for created orders without quoting.
2. Adds support for Görli.