### PR TITLE
Fix make for latest deno

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ dist/index.html: src/index.html dist/index.js
 
 dist/index.js: src/index.js src/lib/ethers.js
 	mkdir -p dist/
-	deno bundle src/index.js dist/index.js
+	deno bundle src/index.js -o dist/index.js
 
 .PHONY: host
 host: dist/index.html


### PR DESCRIPTION
`make host` was only working with an old version deno.

`deno bundle` was deprecated at some point and then re-introduced but with a slightly different syntax in the newest version and this PR makes bundling work with the newest version. 